### PR TITLE
Add config parser

### DIFF
--- a/configlib/parser.py
+++ b/configlib/parser.py
@@ -1,0 +1,25 @@
+import json
+import yaml
+import os
+
+class ConfigParserError(Exception):
+    """Custom error for parser.py"""
+    pass
+
+def load_config(filepath: str) -> dict:
+    """Loads a configuration file in YAML or JSON format"""
+    if not os.path.exists(filepath):
+        raise ConfigParserError(f"File {filepath} does not exist")
+
+    _, ext = os.path.splitext(filepath)
+
+    try:
+        with open(filepath, 'r', encoding='utf-8') as f:
+            if ext in ['.yaml', '.yml']:
+                return yaml.safe_load(f)
+            elif ext == '.json':
+                return json.load(f)
+            else:
+                raise ConfigParserError(f"Unsupported file format: {ext}")
+    except (json.JSONDecodeError, yaml.YAMLError) as e:
+        raise ConfigParserError(f"Syntax error in {filepath}: {e}")

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1,0 +1,33 @@
+import pytest
+from configlib import parser
+import tempfile
+import os
+
+def test_load_yaml_config():
+    yaml_content = "host: localhost\nport: 8080\n"
+    with tempfile.NamedTemporaryFile(delete=False, suffix='.yaml') as tmp:
+        tmp.write(yaml_content.encode('utf-8'))
+        tmp_path = tmp.name
+
+    result = parser.load_config(tmp_path)
+    assert result == {'host': 'localhost', 'port': 8080}
+    os.remove(tmp_path)
+
+def test_load_json_config():
+    json_content = '{"host": "localhost", "port": 8080}'
+    with tempfile.NamedTemporaryFile(delete=False, suffix='.json') as tmp:
+        tmp.write(json_content.encode('utf-8'))
+        tmp_path = tmp.name
+
+    result = parser.load_config(tmp_path)
+    assert result == {'host': 'localhost', 'port': 8080}
+    os.remove(tmp_path)
+
+def test_unsupported_format():
+    with tempfile.NamedTemporaryFile(delete=False, suffix='.txt') as tmp:
+        tmp.write(b"unsupported")
+        tmp_path = tmp.name
+
+    with pytest.raises(parser.ConfigParserError):
+        parser.load_config(tmp_path)
+    os.remove(tmp_path)


### PR DESCRIPTION
Реалізовано функцію load_config для YAML/JSON конфігів.
Додані юніт-тести:
- Завантаження YAML
- Завантаження JSON
- Обробка помилок формату
